### PR TITLE
Update styles for .block.ref.

### DIFF
--- a/layouts/shortcodes/block_img.html
+++ b/layouts/shortcodes/block_img.html
@@ -2,7 +2,7 @@
 {{ $img := (.Get "src") }}
 <div id={{ .Get "indx" }} class="block ref">
     {{ if eq $img_type "svg" }}
-        <object data="{{ $img }}" type="image/svg+xml" style='width:93%'></object>
+        <object data="{{ $img }}" type="image/svg+xml" style='max-width:100%'></object>
     {{ else }}
         <img src="{{ $img }}">
     {{ end }}

--- a/layouts/shortcodes/block_img.html
+++ b/layouts/shortcodes/block_img.html
@@ -2,7 +2,7 @@
 {{ $img := (.Get "src") }}
 <div id={{ .Get "indx" }} class="block ref">
     {{ if eq $img_type "svg" }}
-        <object data="{{ $img }}" type="image/svg+xml" style='max-width:100%'></object>
+        <object data="{{ $img }}" type="image/svg+xml" style='width:93%'></object>
     {{ else }}
         <img src="{{ $img }}">
     {{ end }}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -211,9 +211,8 @@ nav {
 
 
 .block.ref {
-  display: inline-block;
   margin: 1em 0em 1em 1em;
-  padding: 1rem;
+  padding: 0 3px 3px 9px;
   max-width: 800px;
   position: relative;
   overflow-wrap: break-word;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -211,8 +211,9 @@ nav {
 
 
 .block.ref {
+  display: inline-block;
   margin: 1em 0em 1em 1em;
-  padding: 0 3px 3px 9px;
+  padding: 1rem;
   max-width: 800px;
   position: relative;
   overflow-wrap: break-word;


### PR DESCRIPTION
使所有的引用块的背景色都表现出“包裹性”（如图1）

#### 图1
![0](https://user-images.githubusercontent.com/23452609/177913625-24d66850-2a0a-42f6-82fe-a7b5ac6894b7.png)
